### PR TITLE
feat: enable reading segmentation masks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "setuptools.build_meta"
 
 
 [tool.black]
-line-length = 79
+line-length = 100
 target-version = ['py38', 'py39', 'py310']
 
 
 [tool.ruff]
-line-length = 79
+line-length = 100
 select = [
     "E", "F", "W", #flake8
     "UP", # pyupgrade


### PR DESCRIPTION
This PR adds the capability to read segmentation masks. For any ARGOS layer that contains a segmentation mask, a napari labels layer is added. 

Also, i changed the line length for ruff and black to 100.