### PR TITLE
Fix reading of non-matrix argos archives for python < 3.11

### DIFF
--- a/src/napari_argos_archive_reader/__init__.py
+++ b/src/napari_argos_archive_reader/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 from ._reader import napari_get_reader
 

--- a/src/napari_argos_archive_reader/argos_archive_reader.py
+++ b/src/napari_argos_archive_reader/argos_archive_reader.py
@@ -246,7 +246,7 @@ def _read_argos_archive_v1(
     zip_path = zipfile.Path(archive_file)
     zipped_files = list(zip_path.iterdir())
     image_files = list(
-        filter(lambda f: f.suffix.lower() in (".tif", ".png", ".bmp", ".jpg"), zipped_files)
+        filter(lambda f: Path(f.name).suffix.lower() in (".tif", ".png", ".bmp", ".jpg"), zipped_files)
     )
     sorted_image_files = sorted(image_files, key=lambda p: p.name)
     if not len(sorted_image_files):


### PR DESCRIPTION
I was using the property `.suffix` of `zipfile.Path` which was only introduced with python `3.11`. This is a workaround that should work on older Python versions.