### PR TITLE
feat: synchronize contrast limits across layer groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,26 @@ Not supported are:
 * ❌ color metadata
 * ❌ ...
 
-<!--
-Don't miss the full getting started guide to set up your new package:
-https://github.com/napari/cookiecutter-napari-plugin#getting-started
+## Usage
 
-and review the napari docs for plugin developers:
-https://napari.org/stable/plugins/index.html
--->
+### Opening files
+
+Simply drag and drop an ARGOS Archive `.zip` file onto the napari canvas or use `File->Open` to open it.
+
+### Synchronizing contrast limits
+
+By default, after reading an archive, each napari layer will have their own contrast limits, so you can
+adjust these contrast limits individually.
+
+The reader plugin registers a custom key binding after reading an ARGOS archive. Pressing the `s` key will allow
+you to synchronize the contrast limits for a set of layers:
+
+* If you select _a single_ napari layer corresponding to an image/stack from an ARGOS archive, all napari image
+layers that were loaded from this archive now have their contrast limits synchronized, i.e. changing the
+contrast limits of _any_ of them will adjust the contrast limits of _all_ of the layers belonging to the same
+archive.
+* If you select _multiple_ napari layers and press `s` all of these and only these napari layers will have
+their contrast limits synchronized, regardless of whether they belong to the same ARGOS archive or not.
 
 ## Installation
 

--- a/src/napari_argos_archive_reader/__init__.py
+++ b/src/napari_argos_archive_reader/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 from ._reader import napari_get_reader
 

--- a/src/napari_argos_archive_reader/_reader.py
+++ b/src/napari_argos_archive_reader/_reader.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 import typing
 from pathlib import Path
 
+from napari import current_viewer
 from napari.types import LayerDataTuple
 
 from napari_argos_archive_reader.argos_archive_reader import (
     StackInfo,
     read_argos_archive,
 )
+
+from .synchronize import activate_synchronization
 
 
 def napari_get_reader(path):
@@ -106,5 +109,9 @@ def reader_function(path):
     napari_layer_tuples = []
     for napari_stack_info in napari_stacks:
         napari_layer_tuples += _napari_stack_info_to_layer_tuple(napari_stack_info)
+
+    viewer = current_viewer()
+    viewer.bind_key("s", activate_synchronization, overwrite=True)
+    print("Registering keybinding: Press `s` for layer synchronization")
 
     return napari_layer_tuples

--- a/src/napari_argos_archive_reader/synchronize.py
+++ b/src/napari_argos_archive_reader/synchronize.py
@@ -1,0 +1,60 @@
+import typing
+from functools import partial
+
+from napari import Viewer
+from napari.layers import Layer
+
+ARGOS_ARCHIVE_KEY = "argos_archive_file"
+
+
+def is_argos_layer(layer: Layer):
+    if not hasattr(layer, "metadata"):
+        return False
+    if ARGOS_ARCHIVE_KEY not in layer.metadata:
+        return False
+    return True
+
+
+def find_layers_for_archive(archive_file: str, viewer: Viewer):
+    def _filter_func(layer):
+        if not is_argos_layer(layer):
+            return False
+        if layer.metadata[ARGOS_ARCHIVE_KEY] != archive_file:
+            return False
+        return True
+
+    layers = viewer.layers
+    layers_for_archive = list(filter(_filter_func, layers))
+    return layers_for_archive
+
+
+_updating: dict[typing.Tuple[Layer], bool] = {}  # Used to
+
+
+def adjust_contrast_callback(event, layer_group: typing.Tuple[Layer]):
+    global _updating
+    if _updating.get(layer_group, False):
+        return
+    _updating[layer_group] = True
+    source_layer = event.source
+    for layer in set(layer_group) - {source_layer}:
+        # Originally tried using the following context manager
+        # to block events instead of the global _updating.
+        # However, I only want to block this function itself
+        # from creating new events, otherwise the contrast isn't
+        # actually updated. However, I don't know how to get a
+        # reference to itself.
+        # with layer.events.contrast_limits.blocker():
+        layer.contrast_limits = source_layer.contrast_limits
+    _updating[layer_group] = False
+
+
+def synchronize_layer(layer: Layer, viewer: Viewer):
+    if not is_argos_layer(layer):
+        return
+    # TODO assert image layer
+    layer_group = tuple(find_layers_for_archive(layer.metadata[ARGOS_ARCHIVE_KEY], viewer=viewer))
+    callback = partial(adjust_contrast_callback, layer_group=layer_group)
+    for layer in layer_group:
+        print(f"registering {layer.name}")
+        layer.events.contrast_limits.connect(callback)

--- a/src/napari_argos_archive_reader/synchronize.py
+++ b/src/napari_argos_archive_reader/synchronize.py
@@ -49,12 +49,26 @@ def adjust_contrast_callback(event, layer_group: typing.Tuple[Layer]):
     _updating[layer_group] = False
 
 
-def synchronize_layer(layer: Layer, viewer: Viewer):
+def synchronize_argos_layer(layer: Layer, viewer: Viewer):
     if not is_argos_layer(layer):
         return
     # TODO assert image layer
     layer_group = tuple(find_layers_for_archive(layer.metadata[ARGOS_ARCHIVE_KEY], viewer=viewer))
+    print(
+        f"Synchronizing contrast limits in layers for ARGOS archive: {layer.metadata[ARGOS_ARCHIVE_KEY]}"
+    )
     callback = partial(adjust_contrast_callback, layer_group=layer_group)
     for layer in layer_group:
-        print(f"registering {layer.name}")
         layer.events.contrast_limits.connect(callback)
+
+
+def activate_synchronization(viewer: Viewer):
+    sel = viewer.layers.selection
+    if len(sel) == 1 and is_argos_layer(layer := list(sel)[0]):
+        synchronize_argos_layer(layer, viewer)
+    elif len(sel) > 1:
+        layer_group = tuple(sel)
+        print(f"Synchronizing contrast_limits for layers {[layer.name for layer in layer_group]}")
+        callback = partial(adjust_contrast_callback, layer_group=layer_group)
+        for layer in layer_group:
+            layer.events.contrast_limits.connect(callback)


### PR DESCRIPTION
this PR registers the custom keybinding `s`. When pressing `s` layers across the selected Argos archive (or arbitrary layer groups) will have their contrast limits synchronized